### PR TITLE
Fix quote escaping for string highlighting

### DIFF
--- a/syntax/pest.vim
+++ b/syntax/pest.vim
@@ -6,7 +6,7 @@ syntax match pestComment "\/\/.*$" contains=celTodo
 syntax match pestName "^[a-z_][a-z0-9_]*"
 
 " String types
-syntax region pestString start=/"/ end=/"/ oneline contained
+syntax region pestString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contained
 syntax region pestStringIcase start=/\^"/ end=/"/ oneline contained
 syntax region pestChar start=/'/ end=/'/ oneline contained
 

--- a/syntax/pest.vim
+++ b/syntax/pest.vim
@@ -7,7 +7,7 @@ syntax match pestName "^[a-z_][a-z0-9_]*"
 
 " String types
 syntax region pestString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contained
-syntax region pestStringIcase start=/\^"/ end=/"/ oneline contained
+syntax region pestStringIcase start=/\^"/ skip=/\\\\\|\\"/ end=/"/ oneline contained
 syntax region pestChar start=/'/ end=/'/ oneline contained
 
 " Operators, modifiers, keywords


### PR DESCRIPTION
Fixes #1 by skipping escaped quotes and escaped backslashes in string highlighting.