### PR TITLE
Update pest keywords and add rust keywords

### DIFF
--- a/syntax/pest.vim
+++ b/syntax/pest.vim
@@ -13,11 +13,16 @@ syntax region pestChar start=/'/ end=/'/ oneline contained
 " Operators, modifiers, keywords
 syntax match pestModifier "\v[_@$!]"
 syntax match pestOperator "\v[~|*+?&!]" contained
-syntax keyword pestKeyword push contained
-syntax keyword pestSpecial whitespace comment any soi eoi pop peek
+syntax keyword pestKeyword PUSH POP POP_ALL PEEK PEEK_ALL DROP contained
+syntax keyword pestSpecial WHITESPACE COMMENT ANY SOI EOI ASCII_DIGIT ASCII_NONZERO_DIGIT ASCII_BIN_DIGIT ASCII_OCT_DIGIT ASCII_HEX_DIGIT
+      \ ASCII_ALPHA_LOWER ASCII_ALPHA_UPPER ASCII_ALPHA ASCII_ALPHANUMERIC ASCII NEWLINE
+syntax keyword pestForbidden abstract alignof as become box break const continue crate do else enum extern false
+      \ final fn for if impl in let loop macro match mod move mut offsetof override priv proc pure pub ref return
+      \ Self self sizeof static struct super trait true type typeof unsafe unsized use virtual where while yield 
 
 " Rule blocks
-syntax region pestBlock start=/{/ end=/}/ fold transparent contains=pestString,pestStringIcase,pestChar,pestOperator,pestKeyword,pestSpecial
+syntax region pestBlock start=/{/ end=/}/ fold transparent contains=pestString,pestStringIcase,pestChar,pestOperator,pestKeyword,pestSpecial,pestForbidden
+syntax region pestRule start=/^/ end=/ / fold transparent contains=pestName,pestForbidden,pestComment
 
 highlight default link pestTodo Todo
 highlight default link pestComment Comment
@@ -29,3 +34,4 @@ highlight default link pestModifier Operator
 highlight default link pestOperator Operator
 highlight default link pestKeyword Keyword
 highlight default link pestSpecial Type
+highlight default link pestForbidden Error


### PR DESCRIPTION
This PR
* Updates pest keywords to be UPPERCASE.
* Adds Error syntax highlighting for keywords that are forbidden in pest grammars, i.e., already used by Rust.