### PR TITLE
fix: better syntax highlighting

### DIFF
--- a/syntax/pest.vim
+++ b/syntax/pest.vim
@@ -1,9 +1,9 @@
 " Comments
 syntax keyword pestTodo contained TODO FIXME XXX NOTE
-syntax match pestComment "\/\/.*$" contains=celTodo
+syntax match pestComment "\/\/.*$" contains=pestTodo
 
 " Rule names
-syntax match pestName "^[a-z_][a-z0-9_]*"
+syntax match pestName "[a-zA-Z_][a-zA-Z0-9_]*"
 
 " String types
 syntax region pestString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contained
@@ -12,7 +12,8 @@ syntax region pestChar start=/'/ end=/'/ oneline contained
 
 " Operators, modifiers, keywords
 syntax match pestModifier "\v[_@$!]"
-syntax match pestOperator "\v[~|*+?&!]" contained
+syntax match pestTilde "\~"
+syntax match pestOperator "\v[|*+?&!]" contained
 syntax keyword pestKeyword PUSH POP POP_ALL PEEK PEEK_ALL DROP contained
 syntax keyword pestSpecial WHITESPACE COMMENT ANY SOI EOI ASCII_DIGIT ASCII_NONZERO_DIGIT ASCII_BIN_DIGIT ASCII_OCT_DIGIT ASCII_HEX_DIGIT
       \ ASCII_ALPHA_LOWER ASCII_ALPHA_UPPER ASCII_ALPHA ASCII_ALPHANUMERIC ASCII NEWLINE
@@ -113,7 +114,7 @@ syntax keyword pestForbidden abstract alignof as become box break const continue
       \ Self self sizeof static struct super trait true type typeof unsafe unsized use virtual where while yield 
 
 " Rule blocks
-syntax region pestBlock start=/{/ end=/}/ fold transparent contains=pestString,pestStringIcase,pestChar,pestOperator,pestKeyword,pestSpecial,pestGeneral,pestBinary,pestForbidden,pestComment,pestBlock
+syntax region pestBlock matchgroup=pestBraces start=/{/ end=/}/ fold transparent contains=pestString,pestStringIcase,pestChar,pestOperator,pestTilde,pestKeyword,pestSpecial,pestGeneral,pestBinary,pestForbidden,pestComment,pestBlock,pestName
 syntax region pestRule start=/^/ end=/ / fold transparent contains=pestName,pestForbidden,pestComment
 
 highlight default link pestTodo Todo
@@ -123,6 +124,8 @@ highlight default link pestStringIcase String
 highlight default link pestChar Character
 highlight default link pestName Identifier
 highlight default link pestModifier Operator
+highlight default link pestTilde Delimiter
+highlight default link pestBraces Delimiter
 highlight default link pestOperator Operator
 highlight default link pestKeyword Keyword
 highlight default link pestSpecial Type


### PR DESCRIPTION
Before:
<img width="529" alt="image" src="https://github.com/pest-parser/pest.vim/assets/34161949/3aa3ab4b-f583-4861-8852-9ee95a6057aa">

After:
<img width="508" alt="image" src="https://github.com/pest-parser/pest.vim/assets/34161949/7a4f4441-550a-4874-9f7d-12b122b34964">
