### PR TITLE
refactor(lsp): return("lspconfig") is deprecated, updated to use the

### DIFF
--- a/lua/pest-vim/init.lua
+++ b/lua/pest-vim/init.lua
@@ -1,9 +1,8 @@
 local M = {}
 
 function M.setup(opts)
-    -- does not add anything on top of lspconfig currently.
-    -- this may change in the future.
-    require("lspconfig").pest_ls.setup(opts)
+  vim.lsp.config("pest_ls", opts)
+  vim.lsp.enable("pest_ls")
 end
 
 return M


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched Pest language server initialization to use Neovim's built-in LSP system for activation.

* **Documentation**
  * Renamed project references from pest.vim to pest.nvim and updated installation examples and README usage snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->